### PR TITLE
Version info in help text

### DIFF
--- a/looper/looper.py
+++ b/looper/looper.py
@@ -18,6 +18,7 @@ import sys
 import time
 import pandas as _pd
 from . import setup_looper_logger, LOGGING_LEVEL, DEFAULT_LOGGING_FMT
+from utils import VersionInHelpParser
 from _version import __version__
 
 try:
@@ -41,7 +42,7 @@ def parse_arguments():
 	epilog = "For subcommand-specific options, type: '%(prog)s <subcommand> -h'"
 	epilog += "\nhttps://github.com/epigen/looper"
 
-	parser = argparse.ArgumentParser(
+	parser = VersionInHelpParser(
 		description=description, epilog=epilog,
 		formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 	parser.add_argument("-V", "--version", action="version",

--- a/looper/utils.py
+++ b/looper/utils.py
@@ -1,12 +1,22 @@
 """ Helpers without an obvious logical home. """
 
+from argparse import ArgumentParser
 from collections import defaultdict
 import logging
 import os
 import yaml
+from _version import __version__
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+
+class VersionInHelpParser(ArgumentParser):
+    def format_help(self):
+        """ Add version information to help text. """
+        return "version: {}\n".format(__version__) + \
+               super(VersionInHelpParser, self).format_help()
 
 
 


### PR DESCRIPTION
Get version information in help text without redundancy in -V and --version
Fixes https://github.com/epigen/looper/issues/37