### PR TITLE
Revamp logger messages, add  option; See #49, #40

### DIFF
--- a/looper/__init__.py
+++ b/looper/__init__.py
@@ -92,7 +92,7 @@ def setup_looper_logger(level, additional_locations=None,
             handler_type = logging.StreamHandler
         else:
             # Strange supplementary destination
-            logging.warn("{} as logs destination appears to be neither "
+            logging.info("{} as logs destination appears to be neither "
                          "a filepath nor a stream.".format(loc))
             continue
         handler = handler_type(loc)

--- a/looper/__init__.py
+++ b/looper/__init__.py
@@ -25,7 +25,6 @@ LOGGING_LOCATIONS = (stderr, )
 # Default user logging format is simple
 DEFAULT_LOGGING_FMT = "%(message)s"
 # Developer logger format is more information-rich
-#DEFAULT_LOGGING_FMT = "%(asctime)s %(name)s %(module)s : %(lineno)d - [%(levelname)s] > %(message)s"
 DEV_LOGGING_FMT = "%(module)s:%(lineno)d [%(levelname)s] > %(message)s "
 
 

--- a/looper/__init__.py
+++ b/looper/__init__.py
@@ -21,11 +21,17 @@ DEFAULT_LOOPERENV_CONFIG_RELATIVE = os.path.join(SUBMISSION_TEMPLATES_FOLDER,
 
 LOGGING_LEVEL = "INFO"
 LOGGING_LOCATIONS = (stderr, )
-DEFAULT_LOGGING_FMT = "%(asctime)s %(name)s %(module)s : %(lineno)d - [%(levelname)s] > %(message)s"
+
+# Default user logging format is simple
+DEFAULT_LOGGING_FMT = "%(message)s"
+# Developer logger format is more information-rich
+#DEFAULT_LOGGING_FMT = "%(asctime)s %(name)s %(module)s : %(lineno)d - [%(levelname)s] > %(message)s"
+DEV_LOGGING_FMT = "%(module)s:%(lineno)d [%(levelname)s] > %(message)s "
+
 
 
 def setup_looper_logger(level, additional_locations=None,
-                        fmt=None, datefmt=None):
+                        fmt=None, datefmt=None, devmode=False):
     """
     Called by test configuration via `pytest`'s `conftest`.
     All arguments are optional and have suitable defaults.
@@ -40,7 +46,9 @@ def setup_looper_logger(level, additional_locations=None,
 
     # Establish the logger.
     LOOPER_LOGGER = logging.getLogger("looper")
+    # First remove any previously-added handlers
     LOOPER_LOGGER.handlers = []
+    LOOPER_LOGGER.propagate = False
 
     # Handle int- or text-specific logging level.
     try:

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -49,13 +49,12 @@ def parse_arguments():
 
     # Logging control
     parser.add_argument("--logging-level", default=LOGGING_LEVEL,
-                  choices=["DEBUG", "INFO", "WARN", "WARNING", "ERROR"],
                   help=argparse.SUPPRESS)
     parser.add_argument("--logfile", help="Path to central logfile location")
-    parser.add_argument("--dbg", default=False, help=argparse.SUPPRESS,
-                        action="store_true")
+    parser.add_argument("--dbg", action="store_true", help=argparse.SUPPRESS)
+    
     # Template format for logging message
-    parser.add_argument("--logging-fmt", dest="logging_fmt", default=DEFAULT_LOGGING_FMT,
+    parser.add_argument("--logging-fmt", default=DEFAULT_LOGGING_FMT,
                         help=argparse.SUPPRESS)
     parser.add_argument("--logging-datefmt", help=argparse.SUPPRESS)
 

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import time
 import pandas as _pd
-from . import setup_looper_logger, LOGGING_LEVEL, DEFAULT_LOGGING_FMT, __version__
+from . import setup_looper_logger, LOGGING_LEVEL, DEFAULT_LOGGING_FMT, DEV_LOGGING_FMT, __version__
 from utils import VersionInHelpParser
 
 try:
@@ -50,11 +50,14 @@ def parse_arguments():
     # Logging control
     parser.add_argument("--logging-level", default=LOGGING_LEVEL,
                   choices=["DEBUG", "INFO", "WARN", "WARNING", "ERROR"],
-                  help="Minimum level of interest w.r.t. log messages")
+                  help=argparse.SUPPRESS)
     parser.add_argument("--logfile", help="Path to central logfile location")
-    parser.add_argument("--logging-fmt", default=DEFAULT_LOGGING_FMT,
-                        help="Logging message template")
-    parser.add_argument("--logging-datefmt", help="Time formatter for logs")
+    parser.add_argument("--dbg", default=False, help=argparse.SUPPRESS,
+                        action="store_true")
+    # Template format for logging message
+    parser.add_argument("--logging-fmt", dest="logging_fmt", default=DEFAULT_LOGGING_FMT,
+                        help=argparse.SUPPRESS)
+    parser.add_argument("--logging-datefmt", help=argparse.SUPPRESS)
 
     subparsers = parser.add_subparsers(dest='command')
 
@@ -115,6 +118,13 @@ def parse_arguments():
 
     # To enable the loop to pass args directly on to the pipelines...
     args, remaining_args = parser.parse_known_args()
+    
+    if args.dbg:
+        # Set logger into development mode
+        print("Setting looper to developer mode.")
+        args.logging_fmt = DEV_LOGGING_FMT
+        args.logging-level = "DEBUG"
+
     setup_looper_logger(
         args.logging_level, (args.logfile, ),
         fmt=args.logging_fmt, datefmt=args.logging_datefmt)

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -120,10 +120,9 @@ def parse_arguments():
     args, remaining_args = parser.parse_known_args()
     
     if args.dbg:
-        # Set logger into development mode
-        print("Setting looper to developer mode.")
         args.logging_fmt = DEV_LOGGING_FMT
-        args.logging-level = "DEBUG"
+        args.logging_level = "DEBUG"
+        logging.warn("Set looper to developer mode.")
 
     setup_looper_logger(
         args.logging_level, (args.logfile, ),


### PR DESCRIPTION
Fixes the following tasks in #49:

- adds pair of format styles
- cleans up message length
- squelches message duplication (removes default logger handler)

Adds a `--dbg` option (so, `looper --dbg run ...`) which switches into debug mode, adding logger format info and upping level to DEBUG.

Also hides logger CLI options.