### PR TITLE
Project context manager, limit sharing of Project with Sample, provide CLI spec of protocols

### DIFF
--- a/looper/looper.py
+++ b/looper/looper.py
@@ -303,7 +303,7 @@ class Runner(LooperProgram):
                 # instead be accomplished here, disallowing a Project to be passed
                 # to the Sample, as it appears that use of the Project reference
                 # within Sample has been factored out.
-                sample.self.prj = grab_independent_data(self.prj)
+                sample.prj = grab_independent_data(self.prj)
 
                 # The current sample is active.
                 # For each pipeline submission consideration, start fresh.

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -160,7 +160,6 @@ def parse_arguments():
                 "--include-protocols", nargs='*', dest="include_protocols",
                 help="Operate only on samples associated with these protocols; "
                      "if not provided, all samples are used.")
-        subparser.add_argument("")
         subparser.add_argument(
                 "--sp", dest="subproject",
                 help="Name of subproject to use, as designated in the "

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -213,6 +213,8 @@ def run(prj, args, remaining_args, get_samples=None):
     _start_counter(len(samples))
     protocols = {s.protocol for s in samples if hasattr(s, "protocol")}
 
+    _LOGGER.info("Protocols: %s", ", ".join(protocols))
+
     # Keep track of how many jobs have been submitted.
     job_count = 0            # Some job templates will be skipped.
     submit_count = 0         # Some jobs won't be submitted.

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -251,15 +251,11 @@ def run(prj, args, remaining_args, get_samples=None):
             skip_reasons.append("Sample has no protocol")
         else:
             protocol = protocol.upper()
-            _LOGGER.debug("Fetching submission bundle")
-            try:
-                _LOGGER.debug("Using '%s' as protocol key", protocol)
-                submission_bundles = submission_bundle_by_protocol[protocol]
-            except KeyError:
-                skip_reasons.append("No pipeline found for protocol")
-            else:
-                if not submission_bundles:
-                    skip_reasons.append("No submission bundle for protocol")
+            _LOGGER.debug("Fetching submission bundle, "
+                          "using '%s' as protocol key", protocol)
+            submission_bundles = submission_bundle_by_protocol.get(protocol)
+            if not submission_bundles:
+                skip_reasons.append("No submission bundle for protocol")
 
         if skip_reasons:
             _LOGGER.warn("> Not submitted: {}".format(", ".join(skip_reasons)))

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -456,7 +456,7 @@ def run(prj, args, remaining_args, get_samples=None):
     # Report what went down.
     _LOGGER.info("Looper finished")
     _LOGGER.info("Samples generating jobs: %d of %d",
-                 len(processed_samples), num_samples)
+                 len(processed_samples), len(samples))
     _LOGGER.info("Jobs submitted: %d of %d", submit_count, job_count)
     if args.dry_run:
         _LOGGER.info("Dry run. No jobs were actually submitted.")

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -506,6 +506,7 @@ def _iter_proj(prj, get_samples=None):
     return samples
 
 
+
 def summarize(prj, get_samples=None):
     """
     Grab the report_results stats files from each sample and collate them.

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -257,8 +257,9 @@ def run(prj, args, remaining_args, get_samples=None):
                 submission_bundles = submission_bundle_by_protocol[protocol]
             except KeyError:
                 skip_reasons.append("No pipeline found for protocol")
-            if not submission_bundles:
-                skip_reasons.append("No submission bundle for protocol")
+            else:
+                if not submission_bundles:
+                    skip_reasons.append("No submission bundle for protocol")
 
         if skip_reasons:
             _LOGGER.warn("> Not submitted: {}".format(", ".join(skip_reasons)))

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -19,13 +19,15 @@ from .utils import alpha_cased, VersionInHelpParser
 
 try:
     from .models import \
-        fetch_samples, PipelineInterface, ProjectContext, ProtocolMapper, \
+        fetch_samples, grab_independent_data, \
+        PipelineInterface, ProjectContext, ProtocolMapper, \
         Sample, COMPUTE_SETTINGS_VARNAME, SAMPLE_EXECUTION_TOGGLE, \
         VALID_READ_TYPES
 except:
     sys.path.append(os.path.join(os.path.dirname(__file__), "looper"))
     from models import \
-        fetch_samples, PipelineInterface, ProjectContext, ProtocolMapper, \
+        fetch_samples, grab_independent_data, \
+        PipelineInterface, ProjectContext, ProtocolMapper, \
         Sample, COMPUTE_SETTINGS_VARNAME, SAMPLE_EXECUTION_TOGGLE, \
         VALID_READ_TYPES
 
@@ -300,7 +302,7 @@ def run(prj, args, remaining_args, get_samples=None):
             # instead be accomplished here, disallowing a Project to be passed
             # to the Sample, as it appears that use of the Project reference
             # within Sample has been factored out.
-            sample.prj = prj
+            sample.prj = grab_independent_data(prj)
 
             # The current sample is active.
             # For each pipeline submission consideration, start fresh.

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -222,7 +222,7 @@ def run(prj, args, remaining_args, get_samples=None):
     failures = []
 
     _LOGGER.info("Building submission bundle(s) for protocol(s): {}".
-                 format(list(prj.protocols)))
+                 format(", ".join(prj.protocols)))
     submission_bundle_by_protocol = {
             alpha_cased(p): prj.build_submission_bundles(alpha_cased(p))
             for p in protocols

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -150,6 +150,10 @@ def parse_arguments():
                 action="store_true",
                 help="Don't actually submit the project/subproject.")
         subparser.add_argument(
+                "-p", "--protocols", nargs='*', dest="protocols",
+                help="Operate only on samples associated with these protocols; "
+                     "if not provided, all samples are used.")
+        subparser.add_argument(
                 "--sp", dest="subproject",
                 help="Name of subproject to use, as designated in the "
                      "project's configuration file")

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -233,7 +233,7 @@ class Runner(LooperProgram):
         }
 
         for sample in self.prj.samples:
-            _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
+            _LOGGER.info(self.counter.show(sample.sample_name, sample.protocol))
 
             sample_output_folder = self.prj.sample_folder(sample)
             _LOGGER.debug("Sample output folder: '%s'", sample_output_folder)
@@ -735,7 +735,7 @@ def run(prj, args, remaining_args):
     # Report what went down.
     _LOGGER.info("Looper finished")
     _LOGGER.info("Samples generating jobs: %d of %d",
-                 len(processed_samples), len(samples))
+                 len(processed_samples), len(prj.samples))
     _LOGGER.info("Jobs submitted: %d of %d", submit_count, job_count)
     if args.dry_run:
         _LOGGER.info("Dry run. No jobs were actually submitted.")

--- a/looper/looper.py
+++ b/looper/looper.py
@@ -41,7 +41,6 @@ _LEVEL_BY_VERBOSITY = [logging.ERROR, logging.CRITICAL, logging.WARN,
                        logging.INFO, logging.DEBUG]
 
 _LOGGER = logging.getLogger()
-_COUNTER = None
 
 
 
@@ -198,21 +197,127 @@ def parse_arguments():
 
 
 
-class LooperProgram(object):
+class Executor(object):
     """ Base class that ensures the program's Sample counter starts. """
 
+    __metaclass__ = abc.ABCMeta
+
     def __init__(self, prj):
-        super(LooperProgram, self).__init__()
+        """
+        The Project defines the instance; establish an iteration counter.
+        
+        :param Project prj: Project with which to work/operate on
+        """
+        super(Executor, self).__init__()
         self.prj = prj
         self.counter = LooperCounter(len(prj.samples))
 
     @abc.abstractmethod
     def __call__(self, *args, **kwargs):
+        """ Do the work of the subcommand/program. """
         pass
 
 
-class Runner(LooperProgram):
+
+class Cleaner(Executor):
+    """ Remove all intermediate files (defined by pypiper clean scripts). """
+    
+    def __call__(self, args, preview_flag=True):
+        """
+        Execute the file cleaning process.
+        
+        :param argparse.Namespace args: command-line options and arguments
+        :param bool preview_flag: whether to halt before actually removing files 
+        """
+        _LOGGER.info("Files to clean:")
+
+        for sample in self.prj.samples:
+            _LOGGER.info(self.counter.show(sample.sample_name, sample.protocol))
+            sample_output_folder = self.prj.sample_folder(sample)
+            cleanup_files = glob.glob(os.path.join(sample_output_folder,
+                                                   "*_cleanup.sh"))
+            if preview_flag:
+                # Preview: Don't actually clean, just show what will be cleaned.
+                _LOGGER.info("Files to clean: %s", ", ".join(cleanup_files))
+            else:
+                for f in cleanup_files:
+                    _LOGGER.info(f)
+                    subprocess.call(["sh", f])
+
+        if not preview_flag:
+            _LOGGER.info("Clean complete.")
+            return 0
+
+        if args.dry_run:
+            _LOGGER.info("Dry run. No files cleaned.")
+            return 0
+
+        if not query_yes_no("Are you sure you want to permanently delete all "
+                            "intermediate pipeline results for this project?"):
+            _LOGGER.info("Clean action aborted by user.")
+            return 1
+
+        self.counter.reset()
+
+        return self(args, preview_flag=False)
+
+
+
+class Destroyer(Executor):
+    """ Destroyer of files and folders associated with Project's Samples """
+    
+    def __call__(self, args, preview_flag=True):
+        """
+        Completely remove all output produced by any pipelines.
+    
+        :param argparse.Namespace args: command-line options and arguments
+        :param bool preview_flag: whether to halt before actually removing files
+        """
+    
+        _LOGGER.info("Results to destroy:")
+    
+        for sample in self.prj.samples:
+            _LOGGER.info(
+                self.counter.show(sample.sample_name, sample.protocol))
+            sample_output_folder = self.prj.sample_folder(sample)
+            if preview_flag:
+                # Preview: Don't actually delete, just show files.
+                _LOGGER.info(str(sample_output_folder))
+            else:
+                destroy_sample_results(sample_output_folder, args)
+    
+        if not preview_flag:
+            _LOGGER.info("Destroy complete.")
+            return 0
+    
+        if args.dry_run:
+            _LOGGER.info("Dry run. No files destroyed.")
+            return 0
+    
+        if not query_yes_no("Are you sure you want to permanently delete "
+                            "all pipeline results for this project?"):
+            _LOGGER.info("Destroy action aborted by user.")
+            return 1
+
+        self.counter.reset()
+
+        # Finally, run the true destroy:
+        return self(args, preview_flag=False)
+
+
+
+class Runner(Executor):
+    """ The true submitter of pipelines """
+    
     def __call__(self, args, remaining_args):
+        """
+        Do the Sample submission.
+        
+        :param argparse.Namespace args: parsed command-line options and 
+            arguments, recognized by looper 
+        :param list remaining_args: command-line options and arguments not 
+            recognized by looper, germane to samples/pipelines
+        """
         protocols = {s.protocol for s in self.prj.samples if hasattr(s, "protocol")}
 
         _LOGGER.info("Protocols: %s", ", ".join(protocols))
@@ -479,274 +584,105 @@ class Runner(LooperProgram):
                            for failure, samples in sample_by_reason.items()])))
 
 
+class Summarizer(Executor):
+    """ Project/Sample output summarizer """
+    
+    def __call__(self):
+        """ Do the summarization. """
+        import csv
 
-def run(prj, args, remaining_args):
-    """
-    Main Looper function: Submit jobs for samples in project.
+        columns = []
+        stats = []
+        figs = []
 
-    :param models.Project prj: configured Project instance
-    :param argparse.Namespace args: arguments parsed by this module's parser
-    :param Iterable[str] remaining_args: arguments given to this module's 
-        parser that were not defined as options it should parse, 
-        to be passed on to parser(s) elsewhere
-    """
+        for sample in self.prj.samples:
+            _LOGGER.info(self.counter.show(sample.sample_name, sample.protocol))
+            sample_output_folder = self.prj.sample_folder(sample)
 
-    protocols = {s.protocol for s in prj.samples if hasattr(s, "protocol")}
-
-    _LOGGER.info("Protocols: %s", ", ".join(protocols))
-
-    # Keep track of how many jobs have been submitted.
-    job_count = 0            # Some job templates will be skipped.
-    submit_count = 0         # Some jobs won't be submitted.
-    processed_samples = set()
-
-    # Create a problem list so we can keep track and show them at the end.
-    failures = []
-
-    _LOGGER.info("Building submission bundle(s) for protocol(s): {}".
-                 format(", ".join(prj.protocols)))
-    submission_bundle_by_protocol = {
-            alpha_cased(p): prj.build_submission_bundles(alpha_cased(p))
-            for p in protocols
-    }
-
-    for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-
-        sample_output_folder = prj.sample_folder(sample)
-        _LOGGER.debug("Sample output folder: '%s'", sample_output_folder)
-        skip_reasons = []
-
-        # Don't submit samples with duplicate names.
-        if sample.sample_name in processed_samples:
-            skip_reasons.append("Duplicate sample name")
-
-        # Check if sample should be run.
-        if sample.is_dormant():
-            skip_reasons.append("Inactive status (via {})".
-                                format(SAMPLE_EXECUTION_TOGGLE))
-
-        # Get the base protocol-to-pipeline mappings
-        try:
-            protocol = alpha_cased(sample.protocol)
-        except AttributeError:
-            skip_reasons.append("Sample has no protocol")
-        else:
-            protocol = protocol.upper()
-            _LOGGER.debug("Fetching submission bundle, "
-                          "using '%s' as protocol key", protocol)
-            submission_bundles = submission_bundle_by_protocol.get(protocol)
-            if not submission_bundles:
-                skip_reasons.append("No submission bundle for protocol")
-
-        if skip_reasons:
-            _LOGGER.warn("> Not submitted: {}".format(", ".join(skip_reasons)))
-            failures.append([skip_reasons, sample.sample_name])
-            continue
-
-        # TODO: determine what to do with subtype(s) here.
-        # Processing preconditions have been met.
-        processed_samples.add(sample.sample_name)
-
-        # At this point, we have a generic Sample; write that to disk
-        # for reuse in case of many jobs (pipelines) using base Sample.
-        # Do a single overwrite here, then any subsequent Sample can be sure
-        # that the file is fresh, with respect to this run of looper.
-        sample.to_yaml(subs_folder_path=prj.metadata.submission_subdir)
-
-        # Store the base Sample data for reuse in creating subtype(s).
-        sample_data = sample.as_series()
-
-        # Go through all pipelines to submit for this protocol.
-        # Note: control flow doesn't reach this point if variable "pipelines"
-        # cannot be assigned (library/protocol missing).
-        # pipeline_key (previously pl_id) is no longer necessarily
-        # script name, it's more flexible.
-        for pipeline_interface, sample_subtype, pipeline_key, pipeline_job in \
-                submission_bundles:
-            job_count += 1
-
-            _LOGGER.debug("Creating %s instance: '%s'",
-                          sample_subtype.__name__, sample.sample_name)
-            sample = sample_subtype(sample_data)
-
-            # The full Project reference is provided here, but this sample
-            # is only in existence for the duration of the outer loop. Plus,
-            # when the Sample is written to disk as a YAML file, only certain
-            # sections that are more likely to be of use in downstream analysis
-            # are written. Nonetheless, it seems possible that this sort of
-            # bare-bones inclusion of Project data within the Sample could
-            # instead be accomplished here, disallowing a Project to be passed
-            # to the Sample, as it appears that use of the Project reference
-            # within Sample has been factored out.
-            sample.prj = grab_independent_data(prj)
-
-            # The current sample is active.
-            # For each pipeline submission consideration, start fresh.
-            skip_reasons = []
-
-            _LOGGER.debug("Setting pipeline attributes for job '{}' "
-                          "(PL_ID: '{}')".format(pipeline_job, pipeline_key))
-            try:
-                # Add pipeline-specific attributes.
-                sample.set_pipeline_attributes(
-                        pipeline_interface, pipeline_name=pipeline_key)
-            except AttributeError:
-                # TODO: inform about WHICH missing attribute(s).
-                fail_message = "Pipeline required attribute(s) missing"
-                _LOGGER.warn("> Not submitted: %s", fail_message)
-                skip_reasons.append(fail_message)
-
-            # Check for any missing requirements before submitting.
-            _LOGGER.debug("Determining missing requirements")
-            error_type, missing_reqs_msg = \
-                    sample.determine_missing_requirements()
-            if missing_reqs_msg:
-                if prj.permissive:
-                    _LOGGER.warn(missing_reqs_msg)
-                else:
-                    raise error_type(missing_reqs_msg)
-                _LOGGER.warn("> Not submitted: %s", missing_reqs_msg)
-                skip_reasons.append(missing_reqs_msg)
-
-            # Check if single_or_paired value is recognized.
-            if hasattr(sample, "read_type"):
-                # Drop "-end", "_end", or "end" from end of the column value.
-                rtype = re.sub('[_\\-]?end$', '',
-                               str(sample.read_type))
-                sample.read_type = rtype.lower()
-                if sample.read_type not in VALID_READ_TYPES:
-                    _LOGGER.debug(
-                            "Invalid read type: '{}'".format(sample.read_type))
-                    skip_reasons.append("read_type must be in {}".
-                                        format(VALID_READ_TYPES))
-
-            # Identify cluster resources required for this submission.
-            submit_settings = pipeline_interface.choose_resource_package(
-                    pipeline_key, sample.input_file_size)
-
-            # Reset the partition if it was specified on the command-line.
-            try:
-                submit_settings["partition"] = prj.compute.partition
-            except AttributeError:
-                _LOGGER.debug("No partition to reset")
-
-            # Pipeline name is the key used for flag checking.
-            pl_name = pipeline_interface.get_pipeline_name(pipeline_key)
-
-            # Build basic command line string
-            cmd = pipeline_job
-
-            # Append arguments for this pipeline
-            # Sample-level arguments are handled by the pipeline interface.
-            try:
-                argstring = pipeline_interface.get_arg_string(
-                        pipeline_name=pipeline_key, sample=sample,
-                        submission_folder_path=prj.metadata.submission_subdir)
-            except AttributeError:
-                # TODO: inform about which missing attribute(s).
-                fail_message = "Required attribute(s) missing " \
-                               "for pipeline arguments string"
-                _LOGGER.warn("> Not submitted: %s", fail_message)
-                skip_reasons.append(fail_message)
+            # Grab the basic info from the annotation sheet for this sample.
+            # This will correspond to a row in the output.
+            sample_stats = sample.get_sheet_dict()
+            columns.extend(sample_stats.keys())
+            # Version 0.3 standardized all stats into a single file
+            stats_file = os.path.join(sample_output_folder, "stats.tsv")
+            if os.path.isfile(stats_file):
+                _LOGGER.info("Found stats file: '%s'", stats_file)
             else:
-                argstring += " "
-
-            if skip_reasons:
-                # Sample is active, but we've at least 1 pipeline skip reason.
-                failures.append([skip_reasons, sample.sample_name])
+                _LOGGER.warn("No stats file '%s'", stats_file)
                 continue
 
-            _LOGGER.info("> Building submission for Pipeline: '{}' "
-                         "(input: {:.2f} Gb)".format(pipeline_job,
-                                                     sample.input_file_size))
+            t = _pd.read_table(
+                stats_file, header=None, names=['key', 'value', 'pl'])
 
-            # Project-level arguments (sample-agnostic) are handled separately.
-            argstring += prj.get_arg_string(pipeline_key)
-            cmd += argstring
+            t.drop_duplicates(subset=['key', 'pl'], keep='last', inplace=True)
+            # t.duplicated(subset= ['key'], keep = False)
 
-            if pipeline_interface.uses_looper_args(pipeline_key):
-                # These are looper_args, -C, -O, -M, and -P. If the pipeline
-                # implements these arguments, then it lists looper_args=True,
-                # and we add the arguments to the command string.
+            t.loc[:, 'plkey'] = t['pl'] + ":" + t['key']
+            dupes = t.duplicated(subset=['key'], keep=False)
+            t.loc[dupes, 'key'] = t.loc[dupes, 'plkey']
 
-                if hasattr(prj, "pipeline_config"):
-                    # Index with 'pipeline_key' instead of 'pipeline'
-                    # because we don't care about parameters here.
-                    if hasattr(prj.pipeline_config, pipeline_key):
-                        # First priority: pipeline config in project config
-                        pl_config_file = getattr(prj.pipeline_config,
-                                                 pipeline_key)
-                        # Make sure it's a file (it could be provided as null.)
-                        if pl_config_file:
-                            if not os.path.isfile(pl_config_file):
-                                _LOGGER.error("Pipeline config file specified "
-                                              "but not found: %s",
-                                              str(pl_config_file))
-                                raise IOError(pl_config_file)
-                            _LOGGER.info("Found config file: %s",
-                                         str(getattr(prj.pipeline_config,
-                                                     pipeline_key)))
-                            # Append arg for config file if found
-                            cmd += " -C " + pl_config_file
+            sample_stats.update(t.set_index('key')['value'].to_dict())
+            stats.append(sample_stats)
+            columns.extend(t.key.tolist())
 
-                cmd += " -O " + prj.metadata.results_subdir
-                if int(submit_settings.setdefault("cores", 1)) > 1:
-                    cmd += " -P " + submit_settings["cores"]
-                try:
-                    if float(submit_settings["mem"]) > 1:
-                        cmd += " -M " + submit_settings["mem"]
-                except KeyError:
-                    _LOGGER.warn("Submission settings "
-                                 "lack memory specification")
+        self.counter.reset()
 
-            # Add command string and job name to the submit_settings object.
-            submit_settings["JOBNAME"] = \
-                    sample.sample_name + "_" + pipeline_key
-            submit_settings["CODE"] = cmd
-
-            # Create submission script (write script to disk)!
-            _LOGGER.debug("Creating submission script for pipeline %s: '%s'",
-                          pl_name, sample.sample_name)
-            submit_script = create_submission_script(
-                    sample, prj.compute.submission_template, submit_settings,
-                    submission_folder=prj.metadata.submission_subdir,
-                    pipeline_name=pl_name, remaining_args=remaining_args)
-
-            # Determine how to update submission counts and (perhaps) submit.
-            flag_files = glob.glob(os.path.join(
-                    sample_output_folder, pl_name + "*.flag"))
-            if not args.ignore_flags and len(flag_files) > 0:
-                _LOGGER.info("> Not submitting, flag(s) found: {}".
-                             format(flag_files))
-                _LOGGER.debug("NOT SUBMITTED")
+        for sample in self.prj.samples:
+            _LOGGER.info(self.counter.show(sample.sample_name, sample.protocol))
+            sample_output_folder = self.prj.sample_folder(sample)
+            # Now process any reported figures
+            figs_file = os.path.join(sample_output_folder, "figures.tsv")
+            if os.path.isfile(figs_file):
+                _LOGGER.info("Found figures file: '%s'", figs_file)
             else:
-                if args.dry_run:
-                    _LOGGER.info("> DRY RUN: I would have submitted this: '%s'",
-                                 submit_script)
-                else:
-                    submission_command = "{} {}".format(
-                            prj.compute.submission_command, submit_script)
-                    subprocess.call(submission_command, shell=True)
-                    time.sleep(args.time_delay)  # Delay next job's submission.
-                _LOGGER.debug("SUBMITTED")
-                submit_count += 1
+                _LOGGER.warn("No figures file '%s'", figs_file)
+                continue
 
-    # Report what went down.
-    _LOGGER.info("Looper finished")
-    _LOGGER.info("Samples generating jobs: %d of %d",
-                 len(processed_samples), len(prj.samples))
-    _LOGGER.info("Jobs submitted: %d of %d", submit_count, job_count)
-    if args.dry_run:
-        _LOGGER.info("Dry run. No jobs were actually submitted.")
-    if failures:
-        _LOGGER.info("%d sample(s) with submission failure.", len(failures))
-        sample_by_reason = aggregate_exec_skip_reasons(failures)
-        _LOGGER.info("{} unique reasons for submission failure: {}".format(
-                len(sample_by_reason), ", ".join(sample_by_reason.keys())))
-        _LOGGER.info("Samples by failure:\n{}".format(
-            "\n".join(["{}: {}".format(failure, ", ".join(samples))
-                       for failure, samples in sample_by_reason.items()])))
+            t = _pd.read_table(
+                figs_file, header=None, names=['key', 'value', 'pl'])
+
+            t.drop_duplicates(subset=['key', 'pl'], keep='last', inplace=True)
+
+            t.loc[:, 'plkey'] = t['pl'] + ":" + t['key']
+            dupes = t.duplicated(subset=['key'], keep=False)
+            t.loc[dupes, 'key'] = t.loc[dupes, 'plkey']
+
+            figs.append(t)
+
+        # all samples are parsed. Produce file.
+
+        tsv_outfile_path = os.path.join(self.prj.metadata.output_dir, self.prj.name)
+        if self.prj.subproject:
+            tsv_outfile_path += '_' + self.prj.subproject
+        tsv_outfile_path += '_stats_summary.tsv'
+
+        tsv_outfile = open(tsv_outfile_path, 'w')
+
+        tsv_writer = csv.DictWriter(tsv_outfile, fieldnames=uniqify(columns),
+                                    delimiter='\t', extrasaction='ignore')
+        tsv_writer.writeheader()
+
+        for row in stats:
+            tsv_writer.writerow(row)
+
+        tsv_outfile.close()
+
+        figs_tsv_path = "{root}_figs_summary.tsv".format(
+            root=os.path.join(self.prj.metadata.output_dir, self.prj.name))
+
+        figs_html_path = "{root}_figs_summary.html".format(
+            root=os.path.join(self.prj.metadata.output_dir, self.prj.name))
+
+        figs_html_file = open(figs_html_path, 'w')
+
+        img_code = "<h1>{key}</h1><a href='{path}'><img src='{path}'></a>\n"
+        for fig in figs:
+            figs_html_file.write(img_code.format(
+                key=str(fig['key']), path=fig['value']))
+
+        figs_html_file.close()
+        _LOGGER.info(
+            "Summary (n=" + str(len(stats)) + "): " + tsv_outfile_path)
 
 
 
@@ -766,188 +702,6 @@ def aggregate_exec_skip_reasons(skip_reasons_sample_pairs):
         for reason in set(skip_reasons):
             samples_by_skip_reason[reason].append(sample)
     return samples_by_skip_reason
-
-
-
-def summarize(prj):
-    """
-    Grab the report_results stats files from each sample and collate them.
-    The result is a single matrix (written as a csv file).
-
-    :param Project prj: the Project to summarize
-    """
-
-    import csv
-    columns = []
-    stats = []
-    figs = []
-
-    for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-        sample_output_folder = prj.sample_folder(sample)
-
-        # Grab the basic info from the annotation sheet for this sample.
-        # This will correspond to a row in the output.
-        sample_stats = sample.get_sheet_dict()
-        columns.extend(sample_stats.keys())
-        # Version 0.3 standardized all stats into a single file
-        stats_file = os.path.join(sample_output_folder, "stats.tsv")
-        if os.path.isfile(stats_file):
-            _LOGGER.info("Found stats file: '%s'", stats_file)
-        else:
-            _LOGGER.warn("No stats file '%s'", stats_file)
-            continue
-
-        t = _pd.read_table(
-            stats_file, header=None, names=['key', 'value', 'pl'])
-
-        t.drop_duplicates(subset=['key', 'pl'], keep='last', inplace=True)
-        # t.duplicated(subset= ['key'], keep = False)
-
-        t.loc[:, 'plkey'] = t['pl'] + ":" + t['key']
-        dupes = t.duplicated(subset=['key'], keep=False)
-        t.loc[dupes, 'key'] = t.loc[dupes, 'plkey']
-
-        sample_stats.update(t.set_index('key')['value'].to_dict())
-        stats.append(sample_stats)
-        columns.extend(t.key.tolist())
-
-    for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-        sample_output_folder = prj.sample_folder(sample)
-        # Now process any reported figures
-        figs_file = os.path.join(sample_output_folder, "figures.tsv")
-        if os.path.isfile(figs_file):
-            _LOGGER.info("Found figures file: '%s'", figs_file)
-        else:
-            _LOGGER.warn("No figures file '%s'", figs_file)
-            continue
-
-        t = _pd.read_table(
-            figs_file, header=None, names=['key', 'value', 'pl'])
-
-        t.drop_duplicates(subset=['key', 'pl'], keep='last', inplace=True)
-
-        t.loc[:, 'plkey'] = t['pl'] + ":" + t['key']
-        dupes = t.duplicated(subset=['key'], keep=False)
-        t.loc[dupes, 'key'] = t.loc[dupes, 'plkey']
-
-        figs.append(t)
-
-    # all samples are parsed. Produce file.
-
-    tsv_outfile_path = os.path.join(prj.metadata.output_dir, prj.name)
-    if prj.subproject:
-        tsv_outfile_path += '_' + prj.subproject
-    tsv_outfile_path += '_stats_summary.tsv'
-
-    tsv_outfile = open(tsv_outfile_path, 'w')
-
-    tsv_writer = csv.DictWriter(tsv_outfile, fieldnames=uniqify(columns),
-                                delimiter='\t', extrasaction='ignore')
-    tsv_writer.writeheader()
-
-    for row in stats:
-        tsv_writer.writerow(row)
-
-    tsv_outfile.close()
-
-    figs_tsv_path = "{root}_figs_summary.tsv".format(
-        root=os.path.join(prj.metadata.output_dir, prj.name))
-
-
-    figs_html_path = "{root}_figs_summary.html".format(
-        root=os.path.join(prj.metadata.output_dir, prj.name))
-
-    figs_html_file = open(figs_html_path, 'w')
-
-    img_code ="<h1>{key}</h1><a href='{path}'><img src='{path}'></a>\n"
-    for fig in figs:
-        figs_html_file.write(img_code.format(
-            key=str(fig['key']), path=fig['value']))
-
-    figs_html_file.close()
-    _LOGGER.info("Summary (n=" + str(len(stats)) + "): " + tsv_outfile_path)
-
-
-
-def clean(prj, args, preview_flag=True):
-    """
-    Remove all project's intermediate files (defined by pypiper clean scripts).
-
-    :param Project prj: current working Project
-    :param argparse.Namespace args: command-line options and arguments
-    :param bool preview_flag: whether to halt before actually removing files
-    """
-
-    _LOGGER.info("Files to clean:")
-
-    for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-        sample_output_folder = prj.sample_folder(sample)
-        cleanup_files = glob.glob(os.path.join(sample_output_folder,
-                                               "*_cleanup.sh"))
-        if preview_flag:
-            # Preview: Don't actually clean, just show what will be cleaned.
-            _LOGGER.info(str(cleanup_files))
-        else:
-            for f in cleanup_files:
-                _LOGGER.info(f)
-                subprocess.call(["sh", f])
-
-    if not preview_flag:
-        _LOGGER.info("Clean complete.")
-        return 0
-
-    if args.dry_run:
-        _LOGGER.info("Dry run. No files cleaned.")
-        return 0
-
-    if not query_yes_no("Are you sure you want to permanently delete all "
-                        "intermediate pipeline results for this project?"):
-        _LOGGER.info("Clean action aborted by user.")
-        return 1
-
-    return clean(prj, args, preview_flag=False)
-
-
-
-def destroy(prj, args, preview_flag=True):
-    """
-    Completely removes all output files and folders produced by any pipelines.
-
-    :param Project prj: current working Project
-    :param argparse.Namespace args: command-line options and arguments
-    :param bool preview_flag: whether to halt before actually removing files
-    """
-
-    _LOGGER.info("Results to destroy:")
-
-    for sample in prj.samples:
-        _LOGGER.info(_COUNTER.show(sample.sample_name, sample.protocol))
-        sample_output_folder = prj.sample_folder(sample)
-        if preview_flag:
-            # Preview: Don't actually delete, just show files.
-            _LOGGER.info(str(sample_output_folder))
-        else:
-            destroy_sample_results(sample_output_folder, args)
-
-    if not preview_flag:
-        _LOGGER.info("Destroy complete.")
-        return 0
-
-    if args.dry_run:
-        _LOGGER.info("Dry run. No files destroyed.")
-        return 0
-
-    if not query_yes_no("Are you sure you want to permanently delete "
-                        "all pipeline results for this project?"):
-        _LOGGER.info("Destroy action aborted by user.")
-        return 1
-
-    # Finally, run the true destroy:
-
-    return destroy(prj, args, preview_flag=False)
 
 
 
@@ -979,6 +733,9 @@ class LooperCounter(object):
         return _submission_status_text(
                 curr=self.count, total=self.total, sample_name=name,
                 sample_protocol=protocol, color=Fore.CYAN)
+
+    def reset(self):
+        self.count = 0
 
     def __str__(self):
         return "LooperCounter of size {}".format(self.total)
@@ -1092,6 +849,7 @@ def query_yes_no(question, default="no"):
                 "(or 'y' or 'n').\n")
 
 
+
 def destroy_sample_results(result_outfolder, args):
     """
     This function will delete all results for this sample
@@ -1151,18 +909,6 @@ def check(prj):
 
 
 
-def _start_counter(total):
-    """
-    Start counting processed jobs/samples;
-    called by each subcommand program that counts.
-
-    :param int total: upper bound on processing count
-    """
-    global _COUNTER
-    _COUNTER = LooperCounter(total)
-
-
-
 def main():
     # Parse command-line arguments and establish logger.
     args, remaining_args = parse_arguments()
@@ -1199,20 +945,20 @@ def main():
                         "The Project knows no protocols. Does it point "
                         "to at least one pipelines location that exists?")
                 return
+
             run = Runner(prj)
             try:
                 run(args, remaining_args)
-                #run(prj, args, remaining_args)
             except IOError:
                 _LOGGER.error("{} pipelines_dir: '{}'".format(
                         prj.__class__.__name__, prj.metadata.pipelines_dir))
                 raise
 
         if args.command == "destroy":
-            return destroy(prj, args)
+            return Destroyer(prj)(args)
 
         if args.command == "summarize":
-            summarize(prj)
+            Summarizer(prj)()
 
         if args.command == "check":
             # TODO: hook in fixed samples once protocol differentiation is
@@ -1220,7 +966,7 @@ def main():
             check(prj)
 
         if args.command == "clean":
-            clean(prj, args)
+            return Cleaner(prj)(args)
 
 
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -169,7 +169,6 @@ def fetch_samples(proj, inclusion=None, exclusion=None):
         raise ValueError("Specify only inclusion or exclusion protocols, "
                          "not both.")
 
-
     # Ensure that we're working with sets.
     def make_set(maybe_set):
         if isinstance(maybe_set, str):

--- a/looper/models.py
+++ b/looper/models.py
@@ -422,9 +422,6 @@ class Paths(object):
 
 
 
-# TODO: consider removing; currently unused, an alternative to the get_samples
-# TODO (cont.) strategy mechanism in the looper CLI module, for specifying
-# TODO (cont.) protocols with which to select samples over which to iterate.
 class ProjectContext(object):
 
     def __init__(self, prj, include_protocols=None, exclude_protocols=None):

--- a/looper/models.py
+++ b/looper/models.py
@@ -173,9 +173,10 @@ def fetch_samples(proj, inclusion=None, exclusion=None):
     # Ensure that we're working with sets.
     def make_set(maybe_set):
         if isinstance(maybe_set, str):
-            return {maybe_set}
+            items = [maybe_set]
         else:
-            return set(maybe_set or {})
+            items = maybe_set or []
+        return {alpha_cased(i) for i in items}
 
 
     inclusion = make_set(inclusion)
@@ -186,15 +187,19 @@ def fetch_samples(proj, inclusion=None, exclusion=None):
         # offers a list rather than an iterator.
         return list(proj.samples)
 
+    # Use the attr check here rather than exception block in case the
+    # hypothetical AttributeError would occur in alpha_cased; we want such
+    # an exception to arise, not to catch it as if the Sample lacks "protocol"
     if not inclusion:
         # Loose; keep all samples not in the exclusion.
         def keep(s):
-            return not hasattr(s,
-                               "protocol") or s.protocol not in exclusion
+            return not hasattr(s, "protocol") or \
+                   alpha_cased(s.protocol) not in exclusion
     else:
         # Strict; keep only samples in the inclusion.
         def keep(s):
-            return hasattr(s, "protocol") and s.protocol in inclusion
+            return hasattr(s, "protocol") and \
+                   alpha_cased(s.protocol) in inclusion
 
     return [sample for sample in proj.samples if keep(sample)]
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -883,8 +883,6 @@ class Project(AttributeDict):
             _LOGGER.debug("Building basic sample object(s) for %s",
                           self.__class__.__name__)
             self._set_basic_samples()
-        _LOGGER.debug("%s has %d basic sample object(s)",
-                      self.__class__.__name__, len(self._samples))
         return self._samples
 
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -170,22 +170,16 @@ def fetch_samples(proj, inclusion=None, exclusion=None):
         raise TypeError("Specify only inclusion or exclusion protocols, "
                          "not both.")
 
-    # Ensure that we're working with sets.
-    def make_set(maybe_set):
-        if isinstance(maybe_set, str):
-            items = [maybe_set]
-        else:
-            items = maybe_set or []
-        return {alpha_cased(i) for i in items}
-
-
-    inclusion = make_set(inclusion)
-    exclusion = make_set(exclusion)
-
     if not inclusion and not exclusion:
         # Simple; keep all samples.  In this case, this function simply
         # offers a list rather than an iterator.
         return list(proj.samples)
+
+    # Ensure that we're working with sets.
+    def make_set(items):
+        if isinstance(items, str):
+            items = [items]
+        return {alpha_cased(i) for i in items}
 
     # Use the attr check here rather than exception block in case the
     # hypothetical AttributeError would occur in alpha_cased; we want such
@@ -194,14 +188,14 @@ def fetch_samples(proj, inclusion=None, exclusion=None):
         # Loose; keep all samples not in the exclusion.
         def keep(s):
             return not hasattr(s, "protocol") or \
-                   alpha_cased(s.protocol) not in exclusion
+                   alpha_cased(s.protocol) not in make_set(exclusion)
     else:
         # Strict; keep only samples in the inclusion.
         def keep(s):
             return hasattr(s, "protocol") and \
-                   alpha_cased(s.protocol) in inclusion
+                   alpha_cased(s.protocol) in make_set(inclusion)
 
-    return [sample for sample in proj.samples if keep(sample)]
+    return list(filter(keep, proj.samples))
 
 
 

--- a/looper/models.py
+++ b/looper/models.py
@@ -1078,6 +1078,19 @@ class Project(AttributeDict):
             return list(itertools.chain(*job_submission_bundles))
 
 
+    def _check_unique_samples(self):
+        """ Handle scenario in which sample names are not unique. """
+        # Defining this here but then calling out to the repeats counter has
+        # a couple of advantages. We get an unbound, isolated method (the
+        # Project-external repeat sample name counter), but we can still
+        # do this check from the sample builder, yet have it be override-able.
+        num_samples_by_name = count_repeat_samples(self)
+        if num_samples_by_name:
+            _LOGGER.warn("Non-unique sample names:\n{}".format(
+                    "\n".join("{}: {}".format(name, n) for name, n
+                              in num_samples_by_name.items())))
+
+
     def finalize_pipelines_directory(self, pipe_path=""):
         """
         Finalize the establishment of a path to this project's pipelines.
@@ -1158,19 +1171,6 @@ class Project(AttributeDict):
         else:
             # No default argtext, but non-empty pipeline-specific argtext
             return pipeline_argtext
-
-
-    def _check_unique_samples(self):
-        """ Handle scenario in which sample names are not unique. """
-        # Defining this here but then calling out to the repeats counter has
-        # a couple of advantages. We get an unbound, isolated method (the
-        # Project-external repeat sample name counter), but we can still
-        # do this check from the sample builder, yet have it be override-able.
-        num_samples_by_name = count_repeat_samples(self)
-        if num_samples_by_name:
-            _LOGGER.warn("Non-unique sample names:\n{}".format(
-                    "\n".join("{}: {}".format(name, n) for name, n
-                              in num_samples_by_name.items())))
 
 
     def make_project_dirs(self):

--- a/looper/models.py
+++ b/looper/models.py
@@ -436,7 +436,7 @@ class ProjectContext(object):
         if item == "samples":
             return fetch_samples(
                 self.prj, inclusion=self.include, exclusion=self.exclude)
-        if item in ["prj", "include", "exclude", "cached_method"]:
+        if item in ["prj", "include", "exclude"]:
             return self.__dict__[item]
         else:
             return getattr(self.prj, item)

--- a/looper/models.py
+++ b/looper/models.py
@@ -160,13 +160,14 @@ def fetch_samples(proj, inclusion=None, exclusion=None):
     :return list[Sample]: Collection of this Project's samples with
         protocol that either matches one of those in inclusion, or either
         lacks a protocol or does not match one of those in exclusion
-    :raise ValueError: if both inclusion and exclusion protocols are
-        specified
+    :raise TypeError: if both inclusion and exclusion protocols are
+        specified; TypeError since it's basically providing two arguments
+        when only one is accepted, so remain consistent with vanilla Python2
     """
 
     # Intersection between inclusion and exclusion is nonsense user error.
-    if not (inclusion is None or exclusion is None):
-        raise ValueError("Specify only inclusion or exclusion protocols, "
+    if inclusion and exclusion:
+        raise TypeError("Specify only inclusion or exclusion protocols, "
                          "not both.")
 
     # Ensure that we're working with sets.

--- a/looper/models.py
+++ b/looper/models.py
@@ -396,6 +396,9 @@ class Paths(object):
 
 
 
+# TODO: consider removing; currently unused, an alternative to the get_samples
+# TODO (cont.) strategy mechanism in the looper CLI module, for specifying
+# TODO (cont.) protocols with which to select samples over which to iterate.
 class ProjectContext(object):
     def __init__(self, prj, include_protocols=None, exclude_protocols=None):
         self.prj = prj

--- a/looper/models.py
+++ b/looper/models.py
@@ -766,9 +766,12 @@ class Project(AttributeDict):
             raise
 
         self.merge_table = None
+
         # Basic sample maker will handle name uniqueness check.
-        self._samples = None if defer_sample_construction \
-                else self._make_basic_samples()
+        if defer_sample_construction:
+            self._samples = None
+        else:
+            self._set_basic_samples()
 
 
     def __repr__(self):
@@ -879,7 +882,7 @@ class Project(AttributeDict):
         if self._samples is None:
             _LOGGER.debug("Building basic sample object(s) for %s",
                           self.__class__.__name__)
-            self._samples = self._make_basic_samples()
+            self._set_basic_samples()
         _LOGGER.debug("%s has %d basic sample object(s)",
                       self.__class__.__name__, len(self._samples))
         return self._samples
@@ -1170,7 +1173,7 @@ class Project(AttributeDict):
                                  str(e))
 
 
-    def _make_basic_samples(self):
+    def _set_basic_samples(self):
         """ Build the base Sample objects from the annotations sheet data. """
 
         # This should be executed just once, establishing the Project's
@@ -1218,10 +1221,9 @@ class Project(AttributeDict):
                 _LOGGER.log(5, "Path to sample data: '%s'", sample.data_source)
             samples.append(sample)
 
-        # Handle non-unique names situation.
+        # Set samples and handle non-unique names situation.
+        self._samples = samples
         self._check_unique_samples()
-
-        return samples
 
 
     def parse_config_file(self, subproject=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -536,6 +536,10 @@ def proj(request):
     """
     Create project instance using data from file pointed to by request class.
 
+    To use this fixture, the test case must reside within a class that
+    defines a "project_config_file" attribute. This is best done by marking
+    the class with "@pytest.mark.usefixtures("write_project_files")"
+
     :param pytest._pytest.fixtures.SubRequest request: test case requesting
         a project instance
     :return looper.models.Project: object created by parsing
@@ -550,8 +554,11 @@ def proj(request):
 @pytest.fixture(scope="function")
 def pipe_iface(request):
     """
-    Create pipeline interface instance using data from 
-    file pointed to by request class.
+    Create PipelineInterface using data from file pointed to by request class.
+
+    To use this fixture, the test case must reside within a class that
+    defines a "pipe_iface_config_file" attribute. This is best done by marking
+    the class with "@pytest.mark.usefixtures("write_project_files")"
 
     :param pytest._pytest.fixtures.SubRequest request: test case requesting
         a project instance

--- a/tests/models/independent/test_ProjectContext.py
+++ b/tests/models/independent/test_ProjectContext.py
@@ -84,16 +84,23 @@ class ProjectContextTests:
                    (("WGBS", "RRBS"), {WGBS_NAME, RRBS_NAME}),
                    ({"RNA", "CHIP"}, {RNA_NAME, CHIP_NAME})],
         ids=lambda (inclusion, expected): "{}-{}".format(inclusion, expected))
-    def test_inclusion(self, samples, project, expected_names, inclusion):
+    def test_inclusion(self, samples, project, inclusion, expected_names):
         """ Sample objects can be selected for by protocol. """
         _assert_samples(samples, project.samples)
         with ProjectContext(project, include_protocols=inclusion) as prj:
             _assert_sample_names(expected_names, observed_samples=prj.samples)
 
 
-    def test_exclusion(self):
+    @pytest.mark.parametrize(
+        argnames=["exclusion", "expected_names"],
+        argvalues=[({"RNA", "CHIP"}, {ATAC_NAME, WGBS_NAME, RRBS_NAME}),
+                   ("ATAC", {CHIP_NAME, RNA_NAME, WGBS_NAME, RRBS_NAME}),
+                   ({"WGBS", "RRBS"}, {ATAC_NAME, CHIP_NAME, RNA_NAME})])
+    def test_exclusion(self, samples, project, exclusion, expected_names):
         """ Sample objects can be selected against by protocol. """
-        pass
+        _assert_samples(samples, project.samples)
+        with ProjectContext(project, exclude_protocols=exclusion) as prj:
+            _assert_sample_names(expected_names, observed_samples=prj.samples)
 
 
     def test_restoration(self):

--- a/tests/models/independent/test_ProjectContext.py
+++ b/tests/models/independent/test_ProjectContext.py
@@ -103,9 +103,20 @@ class ProjectContextTests:
             _assert_sample_names(expected_names, observed_samples=prj.samples)
 
 
-    def test_restoration(self):
+    @pytest.mark.parametrize(
+        argnames=["selection", "selection_type"],
+        argvalues=[({"CHIP", "WGBS", "RRBS"}, "exclude_protocols"),
+                   ({"WGBS", "ATAC"}, "include_protocols")],
+        ids=lambda (protos, sel_type): "{}:{}".format(protos, sel_type))
+    def test_restoration(self, samples, project, selection, selection_type):
         """ After exiting the context, original Project samples restore. """
-        pass
+        _assert_samples(samples, project.samples)
+        with ProjectContext(project, **{selection_type: selection}) as prj:
+            # Ensure that the context manager has changed something about
+            # the collection of sample names.
+            assert {s.name for s in prj.samples} != {s.name for s in samples}
+        # Ensure the restoration of the original samples.
+        _assert_samples(samples, project.samples)
 
 
     def test_access_to_project_attributes(self):

--- a/tests/models/independent/test_ProjectContext.py
+++ b/tests/models/independent/test_ProjectContext.py
@@ -10,10 +10,16 @@ __author__ = "Vince Reuter"
 __email__ = "vreuter@virginia.edu"
 
 
+ATAC_NAME = "atac-PE"
+CHIP_NAME = "chip1"
+RNA_NAME = "rna_PE"
+WGBS_NAME = "wgbs-hs"
+RRBS_NAME = "rrbs_mm"
+
 
 @pytest.fixture
 def sample_names():
-    return ["atac-PE", "chip1", "rna_PE", "wgbs-hs", "rrbs_ms"]
+    return [ATAC_NAME, CHIP_NAME, RNA_NAME, WGBS_NAME, RRBS_NAME]
 
 
 @pytest.fixture
@@ -61,37 +67,73 @@ def project(request, sample_names, protocols, tmpdir):
 
 
 
-
 class ProjectContextTests:
-    """ Tests for ProjectContext """
+    """ Tests for Project context manager wrapper """
 
 
     def test_no_filtration(self, samples, project):
-        """  """
+        """ With no inclusion/exclusion, all Sample objects are in play. """
         _assert_samples(samples, project.samples)
         with ProjectContext(project) as prj:
             _assert_samples(project.samples, prj.samples)
 
 
-    def test_inclusion(self):
-        pass
+    @pytest.mark.parametrize(
+        argnames=["inclusion", "expected_names"],
+        argvalues=[("ATAC", {"atac-PE"}),
+                   (("WGBS", "RRBS"), {WGBS_NAME, RRBS_NAME}),
+                   ({"RNA", "CHIP"}, {RNA_NAME, CHIP_NAME})],
+        ids=lambda (inclusion, expected): "{}-{}".format(inclusion, expected))
+    def test_inclusion(self, samples, project, expected_names, inclusion):
+        """ Sample objects can be selected for by protocol. """
+        _assert_samples(samples, project.samples)
+        with ProjectContext(project, include_protocols=inclusion) as prj:
+            _assert_sample_names(expected_names, observed_samples=prj.samples)
 
 
     def test_exclusion(self):
+        """ Sample objects can be selected against by protocol. """
         pass
 
 
     def test_restoration(self):
+        """ After exiting the context, original Project samples restore. """
+        pass
+
+
+    def test_access_to_project_attributes(self):
+        """ Context manager routes attribute requests through Project. """
+        pass
+
+
+    def test_access_to_non_project_attributes(self):
+        """ Certain attributes are on the context manager itself. """
         pass
 
 
 
 def _assert_samples(expected_samples, observed_samples):
+    """
+    Make equality assertions on Sample count and names.
+
+    :param Iterable[Sample] expected_samples: collection of expected Sample
+        object instances
+    :param Iterable[Sample] observed_samples: collection of observed Sample
+        object instances
+    """
     assert len(expected_samples) == len(observed_samples)
     assert all(map(lambda (s1, s2): s1.name == s2.name,
                    zip(expected_samples, observed_samples)))
 
 
+
 def _assert_sample_names(expected_names, observed_samples):
+    """
+    Make equality assertions on Sample name and type.
+
+    :param Iterable[str] expected_names: collection of expected Sample names
+    :param Iterable[Sample] observed_samples: collection of observed Sample
+        object instances
+    """
     assert all(map(lambda s: isinstance(s, Sample), observed_samples))
     assert set(expected_names) == {s.name for s in observed_samples}

--- a/tests/models/independent/test_ProjectContext.py
+++ b/tests/models/independent/test_ProjectContext.py
@@ -1,0 +1,97 @@
+""" Tests for temporary contextualization of Project's Sample objects """
+
+import os
+import pytest
+import yaml    # TODO: remove once project can take raw config data?
+from looper.models import Project, Sample, ProjectContext
+
+
+__author__ = "Vince Reuter"
+__email__ = "vreuter@virginia.edu"
+
+
+
+@pytest.fixture
+def sample_names():
+    return ["atac-PE", "chip1", "rna_PE", "wgbs-hs", "rrbs_ms"]
+
+
+@pytest.fixture
+def protocols():
+    return ["ATAC", "CHIP", "RNA", "WGBS", "RRBS"]
+
+
+@pytest.fixture
+def samples(sample_names, protocols):
+    return [Sample({"sample_name": sn, "protocol": p})
+            for sn, p in zip(sample_names, protocols)]
+
+
+@pytest.fixture
+def sample_by_protocol(sample_names, protocols):
+    return dict(zip(protocols, sample_names))
+
+
+@pytest.fixture
+def protocol_by_sample(sample_names, protocols):
+    return dict(zip(sample_names, protocols))
+
+
+@pytest.fixture
+def project(request, sample_names, protocols, tmpdir):
+
+    outdir = os.path.join(tmpdir.strpath, "output")
+    metadir = os.path.join(tmpdir.strpath, "metadata")
+    # So that it's just skipped, deliberately don't create this.
+    pipedir = os.path.join(tmpdir.strpath, "pipelines")
+    map(os.makedirs, [outdir, metadir])
+
+    confpath = os.path.join(metadir, "conf.yaml")
+    annspath = os.path.join(metadir, "anns.csv")
+    conf_data = {"metadata": {
+            "sample_annotation": annspath, "output_dir": outdir}}
+
+    with open(confpath, 'w') as conf:
+        yaml.dump(conf_data, conf)
+    anns_data = [("sample_name", "protocol")] + list(zip(sample_names, protocols))
+    with open(annspath, 'w') as anns:
+        anns.write("\n".join(["{},{}".format(sn, p) for sn, p in anns_data]))
+
+    return Project(confpath)
+
+
+
+
+class ProjectContextTests:
+    """ Tests for ProjectContext """
+
+
+    def test_no_filtration(self, samples, project):
+        """  """
+        _assert_samples(samples, project.samples)
+        with ProjectContext(project) as prj:
+            _assert_samples(project.samples, prj.samples)
+
+
+    def test_inclusion(self):
+        pass
+
+
+    def test_exclusion(self):
+        pass
+
+
+    def test_restoration(self):
+        pass
+
+
+
+def _assert_samples(expected_samples, observed_samples):
+    assert len(expected_samples) == len(observed_samples)
+    assert all(map(lambda (s1, s2): s1.name == s2.name,
+                   zip(expected_samples, observed_samples)))
+
+
+def _assert_sample_names(expected_names, observed_samples):
+    assert all(map(lambda s: isinstance(s, Sample), observed_samples))
+    assert set(expected_names) == {s.name for s in observed_samples}

--- a/tests/models/independent/test_fetch_samples.py
+++ b/tests/models/independent/test_fetch_samples.py
@@ -325,8 +325,7 @@ def _assert_samples(expected_names, observed_samples):
     :param Iterable[Sample] observed_samples: collection of Sample objects,
         e.g. obtained with fetch_samples(), to which assertions apply
     """
-    observed = set(observed_samples)
     expected_names = set(expected_names)
-    assert all([isinstance(s, Sample) for s in observed])
-    observed_names = {s.name for s in observed}
+    assert all([isinstance(s, Sample) for s in observed_samples])
+    observed_names = {s.name for s in observed_samples}
     assert expected_names == observed_names

--- a/tests/models/independent/test_fetch_samples.py
+++ b/tests/models/independent/test_fetch_samples.py
@@ -1,0 +1,77 @@
+""" Tests for fetching Samples of certain protocol(s) from a Project """
+
+import mock
+import pytest
+from looper.models import fetch_samples
+
+
+__author__ = "Vince Reuter"
+__email__ = "vreuter@virginia.edu"
+
+
+
+PROTOCOL_BY_SAMPLE = {"atac_A", "atac_B", "chip1", "WGBS-1", "RRBS-1", "rna_SE", "rna_PE"}
+BASIC_PROTOCOL_NAMES = {"ATAC-Seq", "RNA-Seq", "ChIP-Seq", "WGBS", "RRBS"}
+
+
+
+def generate_protocol_alii(protocol):
+    """ Create case/punctuation-based variants of a protocol name. """
+    return {protocol.upper(), protocol.lower(), protocol.replace("-", "")}
+
+
+
+def test_only_inclusion_or_exclusion():
+    """ Only an inclusion or exclusion set is permitted. """
+    pass
+
+
+
+class NoSamplesTests:
+    """ Regardless of filtration, lack of samples means empty collection. """
+    pass
+
+
+
+class ProtocolInclusionTests:
+    """ Samples can be selected for by protocol. """
+
+    def test_no_inclusions(self):
+        pass
+
+    def test_some_inclusions(self):
+        pass
+
+
+    def test_include_all(self):
+        pass
+
+
+    def test_samples_without_protocol_are_not_included(self):
+        pass
+
+
+
+class ProtocolExclusionTests:
+    """ Samples can be selected against by protocol. """
+
+    def test_no_exclusions(self):
+        pass
+
+
+    def test_some_exclusions(self):
+        pass
+
+
+    def test_exclude_all(self):
+        pass
+
+
+    def test_samples_without_protocol_are_not_excluded(self):
+        pass
+
+
+
+class NoFiltersTests:
+    """ Without a filtration mechanism, all Samples are retained. """
+    pass

--- a/tests/models/independent/test_fetch_samples.py
+++ b/tests/models/independent/test_fetch_samples.py
@@ -1,9 +1,11 @@
 """ Tests for fetching Samples of certain protocol(s) from a Project """
 
+from collections import defaultdict
 import itertools
 import mock
 import pytest
 from looper.models import fetch_samples, Sample
+from looper.utils import alpha_cased
 
 
 __author__ = "Vince Reuter"
@@ -12,51 +14,91 @@ __email__ = "vreuter@virginia.edu"
 
 
 PROTOCOL_BY_SAMPLE = {
-    "atac_A": "ATAC-Seq", "atac_B": "ATAC-Seq",
-    "chip1": "ChIP-Seq", "WGBS-1": "WGBS", "RRBS-1": "RRBS",
-    "rna_SE": "RNA-Seq", "rna_PE": "RNA-Seq"}
-BASIC_PROTOCOL_NAMES = list(itertools.chain(*PROTOCOL_BY_SAMPLE.values()))
+    sample_name: alpha_cased(protocol) for sample_name, protocol in [
+        ("atac_A", "ATAC-Seq"), ("atac_B", "ATAC-Seq"),
+        ("chip1", "ChIP-Seq"), ("WGBS-1", "WGBS"), ("RRBS-1", "RRBS"),
+        ("rna_SE", "RNA-seq"), ("rna_PE", "RNA-seq")]
+}
+BASIC_PROTOCOL_NAMES = set(map(
+    alpha_cased, itertools.chain(*PROTOCOL_BY_SAMPLE.values())))
+
+
+
+def pytest_generate_tests(metafunc):
+    """ Dynamic test case generation for this module. """
+    if "vary_protocol_name" in metafunc.fixturenames:
+        # Create case/punctuation-based variants of a protocol name.
+        # This facilitates validation of the (desirable) fuzziness of the
+        # matching process with respect to protocol name between a Project's
+        # Sample objects and the protocol mappings known to the Project.
+        metafunc.parametrize(
+                argnames="vary_protocol_name",
+                argvalues=[lambda p: p.upper(),
+                           lambda p: p.lower(),
+                           lambda p: p.replace("-", "")])
+
+
+
+def _group_samples_by_protocol():
+    """ Invert mapping from protocol name to sample name.
+
+    :return Mapping[str, list[str]]: sample names by protocol name
+    """
+    name_by_protocol = defaultdict(list)
+    for sn, p in PROTOCOL_BY_SAMPLE.items():
+        name_by_protocol[alpha_cased(p)].append(sn)
+    return name_by_protocol
 
 
 
 @pytest.fixture(scope="function")
-def samples():
-    return [Sample({"sample_name": sn, "protocol": p})
+def expected_sample_names(request):
+    """
+    Generate expected sample names for a test case's fetch_samples() call.
+
+    Use the test case's fixture regarding protocol names to determine which
+    protocols for which to grab sample names.
+
+    :param pytest.fixtures.FixtureRequest request: test case requesting fixture
+    :return set[str]: collection of sample names associated with either the
+        test cases's protocol names (inclusion) or not associated with them
+        (exclusion)
+    """
+    names_by_protocol = _group_samples_by_protocol()
+    if "inclusion" in request.fixturenames:
+        prot_spec = request.getfixturevalue("inclusion")
+    elif "exclusion" in request.fixturenames:
+        prot_spec = request.getfixturevalue("exclusion")
+    else:
+        raise ValueError(
+            "Test case lacks either 'inclusion' and 'exclusion' fixtures, "
+            "so no sample names can be generated; "
+            "it should have one or the other.")
+    if isinstance(prot_spec, str):
+        prot_spec = [prot_spec]
+    prot_spec = set(map(alpha_cased, prot_spec))
+    protocols = prot_spec if "inclusion" in request.fixturenames \
+            else BASIC_PROTOCOL_NAMES - prot_spec
+    print("Protocols generating expectations: {}".format(protocols))
+    return itertools.chain.from_iterable(
+            names_by_protocol[p] for p in protocols)
+
+
+
+@pytest.fixture(scope="function")
+def samples(request):
+    """
+    Create collection of Samples, useful for mocking a Project.
+
+    :return Iterable[Sample]: collection of bare bones Sample objects, with
+        only name and protocol defined
+    """
+    if "vary_protocol_name" in request.fixturenames:
+        vary_proto_name = request.getfixturevalue("vary_protocol_name")
+    else:
+        vary_proto_name = lambda n: n
+    return [Sample({"sample_name": sn, "protocol": vary_proto_name(p)})
             for sn, p in PROTOCOL_BY_SAMPLE.items()]
-
-
-
-def generate_protocol_aliases(protocol):
-    """
-    Create case/punctuation-based variants of a protocol name.
-
-    This method is useful for generating the inputs to test cases that
-    check the fuzziness of a match to protocol, since that's often specified
-    by a user and we don't want to be overly strict about how a protocol
-    must be specified with regard to punctuation and case.
-
-    :param str protocol: a basic protocol name on which to base variants.
-    :return Iterable[str]: collection of protocol name variants based on the
-        given protocol name
-    """
-    return {protocol.upper(), protocol.lower(), protocol.replace("-", "")}
-
-
-
-@pytest.fixture(scope="function")
-def protocol_variant_strategies():
-    """
-    Create case/punctuation-based variants of a protocol name.
-
-    This method is useful for generating the inputs to test cases that
-    check the fuzziness of a match to protocol, since that's often specified
-    by a user and we don't want to be overly strict about how a protocol
-    must be specified with regard to punctuation and case.
-
-    :return Iterable[str]: collection of protocol name variants based on the
-        given protocol name
-    """
-    return [lambda p: p.upper, lambda p: p.lower(), lambda p: p.replace("-", "")]
 
 
 
@@ -74,7 +116,7 @@ def test_only_inclusion_or_exclusion(inclusion, exclusion, samples):
 
 @pytest.mark.parametrize(
     argnames=["inclusion", "exclusion"], argvalues=[
-            ("ATAC", None), ({"ChIPmentation", "RNA-Seq"}, None),
+            ("ATAC-Seq", None), ({"ChIPmentation", "RNA-Seq"}, None),
             (None, "ChIP-Seq"), (None, {"ATAC-Seq", "ChIPmentation"})])
 def test_no_samples(inclusion, exclusion):
     """ Regardless of filtration, lack of samples means empty collection. """
@@ -84,19 +126,60 @@ def test_no_samples(inclusion, exclusion):
 
 
 
+@pytest.mark.parametrize(
+    argnames=["inclusion", "exclusion"],
+    argvalues=[(None, None), (None, {}), ([], None), ([], [])])
+def test_no_filter(inclusion, exclusion, samples):
+    """ Without a filtration mechanism, all Samples are retained. """
+    prj = mock.MagicMock(samples=samples)
+    assert samples == fetch_samples(prj, inclusion, exclusion)
+
+
+
 class ProtocolInclusionTests:
     """ Samples can be selected for by protocol. """
 
-    def test_no_inclusions(self):
-        """ Empty intersection with the inclusion means no Samples. """
-        pass
 
-    def test_some_inclusions(self):
+    @pytest.mark.parametrize(
+        argnames="inclusion",
+        argvalues=["totally-radical-protocol",
+                   ["WackyNewProtocol", "arbitrary_protocol"]])
+    def test_empty_intersection_with_inclusion(
+            self, samples, inclusion, vary_protocol_name):
         """ Sensitivity and specificity for positive protocol selection. """
-        pass
+        prj = mock.MagicMock(samples=samples)
+        observed = fetch_samples(prj, inclusion=inclusion)
+        assert set() == set(observed)
 
 
-    def test_inclusion_covers_all_samples(self):
+    @pytest.mark.parametrize(
+        argnames="inclusion",
+        argvalues=["ATAC-Seq", ("ChIP-Seq", "atacseq"), {"RNA-Seq"}],
+        ids=lambda protos: str(protos))
+    def test_partial_intersection_with_inclusion(self,
+            samples, inclusion, vary_protocol_name, expected_sample_names):
+        """ Empty intersection with the inclusion means no Samples. """
+
+        # Mock the Project instance.
+        prj = mock.MagicMock(samples=samples)
+
+        # Handle both input types.
+        if isinstance(inclusion, str):
+            inclusion = vary_protocol_name(inclusion)
+        else:
+            inclusion = list(map(vary_protocol_name, inclusion))
+
+        # Debug aid (only visible if failed)
+        print("Grouped sample names (by protocol): {}".
+              format(_group_samples_by_protocol()))
+        print("Inclusion specification: {}".format(inclusion))
+
+        # Perform the call under test and make the associated assertions.
+        observed = fetch_samples(prj, inclusion=inclusion)
+        _assert_samples(expected_sample_names, observed)
+
+
+    def test_complete_intersection_with_inclusion(self, vary_protocol_name):
         """ Project with Sample set a subset of inclusion has all fetched. """
         pass
 
@@ -110,17 +193,17 @@ class ProtocolInclusionTests:
 class ProtocolExclusionTests:
     """ Samples can be selected against by protocol. """
 
-    def test_no_exclusions(self):
+    def test_empty_intersection_with_exclusion(self, vary_protocol_name):
         """ Empty intersection with exclusion means all Samples remain. """
         pass
 
 
-    def test_some_exclusions(self):
+    def test_partial_intersection_with_exclusion(self, vary_protocol_name):
         """ Sensitivity and specificity for negative protocol selection. """
         pass
 
 
-    def test_exclusion_covers_all_samples(self):
+    def test_complete_intersection_with_exclusion(self, vary_protocol_name):
         """ Comprehensive exclusion can leave no Samples. """
         pass
 
@@ -131,6 +214,17 @@ class ProtocolExclusionTests:
 
 
 
-class NoFiltersTests:
-    """ Without a filtration mechanism, all Samples are retained. """
-    pass
+def _assert_samples(expected_names, observed_samples):
+    """
+    Assert that each observation is a sample and that the set of expected
+    Sample names agrees with the set of observed names.
+
+    :param Iterable[str] expected_names:
+    :param Iterable[Sample] observed_samples: collection of Sample objects,
+        e.g. obtained with fetch_samples(), to which assertions apply
+    """
+    observed = set(observed_samples)
+    expected_names = set(expected_names)
+    assert all([isinstance(s, Sample) for s in observed])
+    observed_names = set(s.name for s in observed)
+    assert expected_names == observed_names

--- a/tests/models/independent/test_fetch_samples.py
+++ b/tests/models/independent/test_fetch_samples.py
@@ -1,8 +1,9 @@
 """ Tests for fetching Samples of certain protocol(s) from a Project """
 
+import itertools
 import mock
 import pytest
-from looper.models import fetch_samples
+from looper.models import fetch_samples, Sample
 
 
 __author__ = "Vince Reuter"
@@ -10,26 +11,76 @@ __email__ = "vreuter@virginia.edu"
 
 
 
-PROTOCOL_BY_SAMPLE = {"atac_A", "atac_B", "chip1", "WGBS-1", "RRBS-1", "rna_SE", "rna_PE"}
-BASIC_PROTOCOL_NAMES = {"ATAC-Seq", "RNA-Seq", "ChIP-Seq", "WGBS", "RRBS"}
+PROTOCOL_BY_SAMPLE = {
+    "atac_A": "ATAC-Seq", "atac_B": "ATAC-Seq",
+    "chip1": "ChIP-Seq", "WGBS-1": "WGBS", "RRBS-1": "RRBS",
+    "rna_SE": "RNA-Seq", "rna_PE": "RNA-Seq"}
+BASIC_PROTOCOL_NAMES = list(itertools.chain(*PROTOCOL_BY_SAMPLE.values()))
 
 
 
-def generate_protocol_alii(protocol):
-    """ Create case/punctuation-based variants of a protocol name. """
+@pytest.fixture(scope="function")
+def samples():
+    return [Sample({"sample_name": sn, "protocol": p})
+            for sn, p in PROTOCOL_BY_SAMPLE.items()]
+
+
+
+def generate_protocol_aliases(protocol):
+    """
+    Create case/punctuation-based variants of a protocol name.
+
+    This method is useful for generating the inputs to test cases that
+    check the fuzziness of a match to protocol, since that's often specified
+    by a user and we don't want to be overly strict about how a protocol
+    must be specified with regard to punctuation and case.
+
+    :param str protocol: a basic protocol name on which to base variants.
+    :return Iterable[str]: collection of protocol name variants based on the
+        given protocol name
+    """
     return {protocol.upper(), protocol.lower(), protocol.replace("-", "")}
 
 
 
-def test_only_inclusion_or_exclusion():
+@pytest.fixture(scope="function")
+def protocol_variant_strategies():
+    """
+    Create case/punctuation-based variants of a protocol name.
+
+    This method is useful for generating the inputs to test cases that
+    check the fuzziness of a match to protocol, since that's often specified
+    by a user and we don't want to be overly strict about how a protocol
+    must be specified with regard to punctuation and case.
+
+    :return Iterable[str]: collection of protocol name variants based on the
+        given protocol name
+    """
+    return [lambda p: p.upper, lambda p: p.lower(), lambda p: p.replace("-", "")]
+
+
+
+@pytest.mark.parametrize(
+    argnames=["inclusion", "exclusion"], argvalues=itertools.product(
+            ["ATAC-Seq", "ChIPmentation", {"RNA-Seq", "ChIP"}],
+            ["WGBS", {"WGBS", "RRBS"}]))
+def test_only_inclusion_or_exclusion(inclusion, exclusion, samples):
     """ Only an inclusion or exclusion set is permitted. """
-    pass
+    prj = mock.MagicMock(samples=samples)
+    with pytest.raises(TypeError):
+        fetch_samples(prj, inclusion, exclusion)
 
 
 
-class NoSamplesTests:
+@pytest.mark.parametrize(
+    argnames=["inclusion", "exclusion"], argvalues=[
+            ("ATAC", None), ({"ChIPmentation", "RNA-Seq"}, None),
+            (None, "ChIP-Seq"), (None, {"ATAC-Seq", "ChIPmentation"})])
+def test_no_samples(inclusion, exclusion):
     """ Regardless of filtration, lack of samples means empty collection. """
-    pass
+    prj = mock.MagicMock(samples=[])
+    observed = fetch_samples(prj, inclusion, exclusion)
+    assert [] == observed
 
 
 
@@ -37,17 +88,21 @@ class ProtocolInclusionTests:
     """ Samples can be selected for by protocol. """
 
     def test_no_inclusions(self):
+        """ Empty intersection with the inclusion means no Samples. """
         pass
 
     def test_some_inclusions(self):
+        """ Sensitivity and specificity for positive protocol selection. """
         pass
 
 
-    def test_include_all(self):
+    def test_inclusion_covers_all_samples(self):
+        """ Project with Sample set a subset of inclusion has all fetched. """
         pass
 
 
     def test_samples_without_protocol_are_not_included(self):
+        """ Inclusion does not grab Sample lacking protocol. """
         pass
 
 
@@ -56,18 +111,22 @@ class ProtocolExclusionTests:
     """ Samples can be selected against by protocol. """
 
     def test_no_exclusions(self):
+        """ Empty intersection with exclusion means all Samples remain. """
         pass
 
 
     def test_some_exclusions(self):
+        """ Sensitivity and specificity for negative protocol selection. """
         pass
 
 
-    def test_exclude_all(self):
+    def test_exclusion_covers_all_samples(self):
+        """ Comprehensive exclusion can leave no Samples. """
         pass
 
 
     def test_samples_without_protocol_are_not_excluded(self):
+        """ Negative selection on protocol leaves Samples without protocol. """
         pass
 
 

--- a/tests/models/independent/test_fetch_samples.py
+++ b/tests/models/independent/test_fetch_samples.py
@@ -179,9 +179,14 @@ class ProtocolInclusionTests:
         _assert_samples(expected_sample_names, observed)
 
 
-    def test_complete_intersection_with_inclusion(self, vary_protocol_name):
+    def test_complete_intersection_with_inclusion(
+            self, samples, vary_protocol_name):
         """ Project with Sample set a subset of inclusion has all fetched. """
-        pass
+        prj = mock.MagicMock(samples=samples)
+        expected = {s.name for s in samples}
+        observed = fetch_samples(
+            prj, inclusion=list(map(vary_protocol_name, BASIC_PROTOCOL_NAMES)))
+        _assert_samples(expected, observed)
 
 
     def test_samples_without_protocol_are_not_included(self):
@@ -226,5 +231,5 @@ def _assert_samples(expected_names, observed_samples):
     observed = set(observed_samples)
     expected_names = set(expected_names)
     assert all([isinstance(s, Sample) for s in observed])
-    observed_names = set(s.name for s in observed)
+    observed_names = {s.name for s in observed}
     assert expected_names == observed_names


### PR DESCRIPTION
The programs in `looper.py` share an iteration pattern. Sometimes I want to operate on only certain protocols. This could be accomplished with a subproject, but then I need to write a new annotations sheet or use `toggle` and possibly also edit the project configuration file itself to defined subproject(s).

These changes provide a CLI-based mechanism for specifying the protocols of `Sample` objects that a program should operate on / work with when the program indicated by the subcommand like `summarize` is used. This also provides a light context manager wrapper around a `Project` itself; iteration semantics remains the same within each of the programs (i.e., `prj.samples`-like syntax) regardless of whether `prj` represents the context manager or an actual `Project`, but iteration is contextualized by protocols to include or exclude.

`looper.py` subcommands/programs are converted to classes that share a base class, which takes care of ensuring that the counting is done consistently and doesn't need to be replicated for each program. Handling is standardized, and the global counter is moved to within a program instance. I think this simplifies integrating a new subcommand/program into the mix and having it behave in a fashion similar to the others.